### PR TITLE
Remove Validation

### DIFF
--- a/RDF.Arcana.API/Features/Requests Approval/GetApproverByRange.cs
+++ b/RDF.Arcana.API/Features/Requests Approval/GetApproverByRange.cs
@@ -71,10 +71,10 @@ public class GetApproverByRange : ControllerBase
                 .Where(m => m.ModuleName == request.ModuleName)
                 .ToListAsync(cancellationToken);
 
-            if (!existingApprovers.Any())
-            {
-                return ApprovalErrors.NoApproversFound(request.ModuleName);
-            }
+            //if (!existingApprovers.Any())
+            //{
+            //    return ApprovalErrors.NoApproversFound(request.ModuleName);
+            //}
 
             var approvers = existingApprovers.Select(a => new GetAppproverByModuleByRangeResult.Approver
             {


### PR DESCRIPTION
Remove Validation from GetApproverByRange to return nothing even with mismatch module name rather than an error.